### PR TITLE
[ko] Translate docs/reference/glossary/contributor.md

### DIFF
--- a/content/ko/docs/reference/glossary/contributor.md
+++ b/content/ko/docs/reference/glossary/contributor.md
@@ -1,0 +1,18 @@
+---
+title: 컨트리뷰터(Contributor)
+id: contributor
+date: 2018-04-12
+full_link:
+short_description: >
+    쿠버네티스 프로젝트 또는 커뮤니티를 돕기 위해 코드, 문서 또는 시간을 기부하는 사람.
+
+aka:
+tags:
+    - community
+---
+
+쿠버네티스 프로젝트 또는 커뮤니티를 돕기 위해 코드, 문서 또는 시간을 기부하는 사람.
+
+<!--more-->
+
+기여에는 풀 리퀘스트(PR), 이슈, 피드백, {{< glossary_tooltip text="분과회(special interest groups)" term_id="sig" >}} 참여, 또는 커뮤니티 행사 조직이 포함됩니다.


### PR DESCRIPTION
This is a Feature Request
Translate [docs/reference/glossary/contributor.md](https://github.com/chewing-git/website/blob/dev-1.13-ko.1/content/en/docs/reference/glossary/contributor.md) in Korean

What would you like to be added

Translate [docs/reference/glossary/contributor.md](https://github.com/chewing-git/website/blob/dev-1.13-ko.1/content/en/docs/reference/glossary/contributor.md) in Korean

Why is this needed
This file is not translated yet.